### PR TITLE
[QoL] Makefile addition. Makes both usage and dev more friendly.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: build up down logs logs-web logs-n8n
+
+build:
+	docker compose build
+
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+logs:
+	docker compose logs -f
+
+logs-web:
+	docker compose logs -f web
+
+logs-n8n:
+	docker compose logs -f n8n
+

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ git clone https://github.com/HotTechStack/dataagents.git
 cd dataagents
 
 # Start the application
-docker-compose up -d
+make up
 ```
 
 ### 🔧 Setup Steps


### PR DESCRIPTION
## Description

This PR introduces several `make` targets (e.g., `make up`, `make down`, `make logs`) to simplify common Docker Compose commands and improve developer experience, addressing the repetitive nature of typing `docker compose ...`.
For consistency sake might want to add `make run` and `make install` among some other things, but at this point it's purely stylistic.

Container specific logs have also been quite helpful.
While reviewing container logs using the new `make logs-n8n` target, an interesting observation was made: even during successful chat pipeline executions, the `n8n` container logs frequently show errors like:

```log
Error in handler N8nLlmTracing, handleLLMStart: TypeError: fetch failed
Error in handler N8nLlmTracing, handleLLMEnd: TypeError: fetch failed
```

NOTE: this does not affect the core functionality of the chat pipeline but is noted here for awareness.
Might require further investigation, but not sure if it's `issue worthy` as it's a silent error and in no way a showstopper.